### PR TITLE
Added min number of runs per batch

### DIFF
--- a/R/fParallel.R
+++ b/R/fParallel.R
@@ -1,4 +1,4 @@
-solveInParallelSteadyState <- function(max_runs_per_batch,
+solveInParallelSteadyState <- function(max_runs_per_slice,
                             nCores,
                             emissions_data,
                             correlations = NULL, 
@@ -6,11 +6,12 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
                             world_path = "data/World.RDS"
                             ) {
   ###################### Input Validation
-  if (is.null(max_runs_per_batch)) {
-    stop("Error: max_runs_per_batch cannot be NULL. Please provide a valid value.")
+  if (is.null(max_runs_per_slice)) {
+    stop("Error: max_runs_per_slice cannot be NULL. Please provide a valid value.")
   }
-  if (max_runs_per_batch < 2) {
-    stop("solveInParallelSteadyState: runs per batch (max_runs_per_batch) cannot be smaller than 2")}
+  if (max_runs_per_slice < 2) {
+    stop("solveInParallelSteadyState: runs per slice (max_runs_per_slice) cannot be smaller than 2")
+    }
   if (is.null(nCores)) {
     stop("Error: nCores cannot be NULL. Please provide a valid number of cores.")
   }
@@ -26,39 +27,20 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
   # Number of runs in the LHS matrix
   total_runs <- ncol(LHSsamples)
   
-  # Minimum runs per batch
-  min_runs_per_batch <- 2
+  # Minimum runs per slice
+  min_runs_per_slice <- 2
   
-  # Maximum runs per batch (zoals opgegeven)
-  max_runs_per_batch <- max_runs_per_batch
+  # Estimate minimal amount of slices baed on max_runs_per_slice
+  nslices <- ceiling(total_runs / max_runs_per_slice)
   
-  # Estimate minimal amount of batches baed on max_runs_per_batch
-  nbatches <- ceiling(total_runs / max_runs_per_batch)
-  
-  # Create runs_distribution with amount of runs per batch
-  runs_distribution <- rep(floor(total_runs / nbatches), nbatches)
+  # Create runs_distribution with amount of runs per slice
+  runs_distribution <- rep(floor(total_runs / nslices), nslices)
   remaining <- total_runs - sum(runs_distribution)
   
   # Redistribute the runs which remain over runs_distribution
   if (remaining > 0) {
     runs_distribution[1:remaining] <- runs_distribution[1:remaining] + 1
   }
-  
-  # Make sure all batches have at least 2 runs
-  # This avoids emission errors, due to the way the emissions module currently works
-  # if (any(runs_distribution < min_runs_per_batch)) {
-  #   # Combine small batches with their neighbor
-  #   while (any(runs_distribution < min_runs_per_batch)) {
-  #     idx <- which(runs_distribution < min_runs_per_batch)[1]
-  #     if (idx > 1) {
-  #       runs_distribution[idx - 1] <- runs_distribution[idx - 1] + runs_distribution[idx]
-  #       runs_distribution <- runs_distribution[-idx]
-  #     } else {
-  #       runs_distribution[idx + 1] <- runs_distribution[idx + 1] + runs_distribution[idx]
-  #       runs_distribution <- runs_distribution[-idx]
-  #     }
-  #   }
-  # }
   
   # Split emissions data into chunks using the runs_distribution
   emis_slices <- list()
@@ -69,7 +51,7 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
     start_index <- end_index + 1
   }
   
-  # Slice the LHS samples into chunks, matching the batch distribution
+  # Slice the LHS samples into chunks, matching the slice distribution
   LHS_slices <- list()
   start_index <- 1
   for (run in runs_distribution) {
@@ -148,7 +130,7 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
   return(Solution)
 }
 
-solveInParallelDynamic <- function(max_runs_per_batch,
+solveInParallelDynamic <- function(max_runs_per_slice,
                                    nCores,
                                    emissions_data, 
                                    tmin, 
@@ -160,8 +142,11 @@ solveInParallelDynamic <- function(max_runs_per_batch,
                                    ) {
 
   ###################### Input Validation
-  if (is.null(max_runs_per_batch)) {
-    stop("Error: max_runs_per_batch cannot be NULL. Please provide a valid value.")
+  if (is.null(max_runs_per_slice)) {
+    stop("Error: max_runs_per_slice cannot be NULL. Please provide a valid value.")
+  }
+  if (is.null(max_runs_per_slice)) {
+    stop("Error: max_runs_per_slice cannot be NULL. Please provide a valid value.")
   }
   if (is.null(nCores)) {
     stop("Error: nCores cannot be NULL. Please provide a valid number of cores.")
@@ -184,42 +169,24 @@ solveInParallelDynamic <- function(max_runs_per_batch,
   
   ###################### Step 2: Prepare emissions and LHS samples for parallel solving
 
-    # Number of runs in the LHS matrix
+  # Number of runs in the LHS matrix
   total_runs <- ncol(LHSsamples)
   
-  # Minimum runs per batch
-  min_runs_per_batch <- 2
+  # Minimum runs per slice
+  min_runs_per_slice <- 2
   
-  # Maximum runs per batch (zoals opgegeven)
-  max_runs_per_batch <- max_runs_per_batch
+  # Estimate minimal amount of slices based on max_runs_per_slice
+  nslices <- ceiling(total_runs / max_runs_per_slice)
   
-  # Bepaal het minimale aantal batches zodat elke batch minstens 2 runs heeft
-  nbatches <- ceiling(total_runs / max_runs_per_batch)
-  
-  # Herverdeel de runs zodat elke batch minstens 2 runs heeft
-  runs_distribution <- rep(floor(total_runs / nbatches), nbatches)
+  # Create runs_distribution with amount of runs per slice
+  runs_distribution <- rep(floor(total_runs / nslices), nslices)
   remaining <- total_runs - sum(runs_distribution)
   
-  # Verdeel de overgebleven runs over de eerste batches
+  # Verdeel de overgebleven runs over de eerste slicees
   if (remaining > 0) {
     runs_distribution[1:remaining] <- runs_distribution[1:remaining] + 1
   }
-  
-  # Controleer of alle batches minstens 2 runs hebben
-  if (any(runs_distribution < min_runs_per_batch)) {
-    # Combineer kleine batches met hun buurman
-    while (any(runs_distribution < min_runs_per_batch)) {
-      idx <- which(runs_distribution < min_runs_per_batch)[1]
-      if (idx > 1) {
-        runs_distribution[idx - 1] <- runs_distribution[idx - 1] + runs_distribution[idx]
-        runs_distribution <- runs_distribution[-idx]
-      } else {
-        runs_distribution[idx + 1] <- runs_distribution[idx + 1] + runs_distribution[idx]
-        runs_distribution <- runs_distribution[-idx]
-      }
-    }
-  }
-  
+
   # Split emissions data into chunks using the runs_distribution
   emis_slices <- list()
   start_index <- 1
@@ -229,7 +196,7 @@ solveInParallelDynamic <- function(max_runs_per_batch,
     start_index <- end_index + 1
   }
   
-  # Slice the LHS samples into chunks, matching the batch distribution
+  # Slice the LHS samples into chunks, matching the slice distribution
   LHS_slices <- list()
   start_index <- 1
   for (run in runs_distribution) {

--- a/R/fParallel.R
+++ b/R/fParallel.R
@@ -41,8 +41,8 @@ solveInParallelSteadyState <- function(max_runs_per_slice,
   if (remaining > 0) {
     runs_distribution[1:remaining] <- runs_distribution[1:remaining] + 1
   }
-  
-  # Split emissions data into chunks using the runs_distribution
+
+  # Split emissions data into slices using the runs_distribution
   emis_slices <- list()
   start_index <- 1
   for (runs in runs_distribution) {
@@ -51,7 +51,7 @@ solveInParallelSteadyState <- function(max_runs_per_slice,
     start_index <- end_index + 1
   }
   
-  # Slice the LHS samples into chunks, matching the slice distribution
+  # Split the LHS samples into slices using the runs_distribution
   LHS_slices <- list()
   start_index <- 1
   for (run in runs_distribution) {
@@ -182,12 +182,12 @@ solveInParallelDynamic <- function(max_runs_per_slice,
   runs_distribution <- rep(floor(total_runs / nslices), nslices)
   remaining <- total_runs - sum(runs_distribution)
   
-  # Verdeel de overgebleven runs over de eerste slicees
+  # Redistribute the runs which remain over runs_distribution
   if (remaining > 0) {
     runs_distribution[1:remaining] <- runs_distribution[1:remaining] + 1
   }
 
-  # Split emissions data into chunks using the runs_distribution
+  # Split emissions data into slices using the runs_distribution
   emis_slices <- list()
   start_index <- 1
   for (runs in runs_distribution) {
@@ -196,7 +196,7 @@ solveInParallelDynamic <- function(max_runs_per_slice,
     start_index <- end_index + 1
   }
   
-  # Slice the LHS samples into chunks, matching the slice distribution
+  # Split LHS samples into slices using the runs_distribution
   LHS_slices <- list()
   start_index <- 1
   for (run in runs_distribution) {

--- a/R/fParallel.R
+++ b/R/fParallel.R
@@ -5,11 +5,12 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
                             LHSsamples_path = "data/scaledLHSsamples.RDS",
                             world_path = "data/World.RDS"
                             ) {
-
   ###################### Input Validation
   if (is.null(max_runs_per_batch)) {
     stop("Error: max_runs_per_batch cannot be NULL. Please provide a valid value.")
   }
+  if (max_runs_per_batch < 2) {
+    stop("solveInParallelSteadyState: runs per batch (max_runs_per_batch) cannot be smaller than 2")}
   if (is.null(nCores)) {
     stop("Error: nCores cannot be NULL. Please provide a valid number of cores.")
   }
@@ -45,19 +46,19 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
   
   # Make sure all batches have at least 2 runs
   # This avoids emission errors, due to the way the emissions module currently works
-  if (any(runs_distribution < min_runs_per_batch)) {
-    # Combine small batches with their neighbor
-    while (any(runs_distribution < min_runs_per_batch)) {
-      idx <- which(runs_distribution < min_runs_per_batch)[1]
-      if (idx > 1) {
-        runs_distribution[idx - 1] <- runs_distribution[idx - 1] + runs_distribution[idx]
-        runs_distribution <- runs_distribution[-idx]
-      } else {
-        runs_distribution[idx + 1] <- runs_distribution[idx + 1] + runs_distribution[idx]
-        runs_distribution <- runs_distribution[-idx]
-      }
-    }
-  }
+  # if (any(runs_distribution < min_runs_per_batch)) {
+  #   # Combine small batches with their neighbor
+  #   while (any(runs_distribution < min_runs_per_batch)) {
+  #     idx <- which(runs_distribution < min_runs_per_batch)[1]
+  #     if (idx > 1) {
+  #       runs_distribution[idx - 1] <- runs_distribution[idx - 1] + runs_distribution[idx]
+  #       runs_distribution <- runs_distribution[-idx]
+  #     } else {
+  #       runs_distribution[idx + 1] <- runs_distribution[idx + 1] + runs_distribution[idx]
+  #       runs_distribution <- runs_distribution[-idx]
+  #     }
+  #   }
+  # }
   
   # Split emissions data into chunks using the runs_distribution
   emis_slices <- list()
@@ -85,8 +86,8 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
   nSlices <- length(emis_slices)
   
   # Create a parallel cluster
-  cl <- makeCluster(nCores)
-  registerDoParallel(cl)
+  cl <- parallel::makeCluster(nCores)
+  doParallel::registerDoParallel(cl)
   
   # Define the worker function for each slice
   processSlice <- function(i) {

--- a/R/fParallel.R
+++ b/R/fParallel.R
@@ -243,8 +243,8 @@ solveInParallelDynamic <- function(max_runs_per_batch,
   ###################### Step 3: Solve in parallel
   nSlices <- length(emis_slices)
   
-  cl <- makeCluster(nCores)
-  registerDoParallel(cl)
+  cl <- parallel::makeCluster(nCores)
+  doParallel::registerDoParallel(cl)
   
   processSlice <- function(i) {
     # Source required scripts

--- a/R/fParallel.R
+++ b/R/fParallel.R
@@ -67,9 +67,12 @@ solveInParallelSteadyState <- function(max_runs_per_slice,
   # Number of slices
   nSlices <- length(emis_slices)
   
+  # Load required library
+  library("doParallel")
+  
   # Create a parallel cluster
-  cl <- parallel::makeCluster(nCores)
-  doParallel::registerDoParallel(cl)
+  cl <- makeCluster(nCores)
+  registerDoParallel(cl)
   
   # Define the worker function for each slice
   processSlice <- function(i) {

--- a/R/fParallel.R
+++ b/R/fParallel.R
@@ -5,7 +5,7 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
                             LHSsamples_path = "data/scaledLHSsamples.RDS",
                             world_path = "data/World.RDS"
                             ) {
-  
+
   ###################### Input Validation
   if (is.null(max_runs_per_batch)) {
     stop("Error: max_runs_per_batch cannot be NULL. Please provide a valid value.")
@@ -31,21 +31,22 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
   # Maximum runs per batch (zoals opgegeven)
   max_runs_per_batch <- max_runs_per_batch
   
-  # Bepaal het minimale aantal batches zodat elke batch minstens 2 runs heeft
+  # Estimate minimal amount of batches baed on max_runs_per_batch
   nbatches <- ceiling(total_runs / max_runs_per_batch)
   
-  # Herverdeel de runs zodat elke batch minstens 2 runs heeft
+  # Create runs_distribution with amount of runs per batch
   runs_distribution <- rep(floor(total_runs / nbatches), nbatches)
   remaining <- total_runs - sum(runs_distribution)
   
-  # Verdeel de overgebleven runs over de eerste batches
+  # Redistribute the runs which remain over runs_distribution
   if (remaining > 0) {
     runs_distribution[1:remaining] <- runs_distribution[1:remaining] + 1
   }
   
-  # Controleer of alle batches minstens 2 runs hebben
+  # Make sure all batches have at least 2 runs
+  # This avoids emission errors, due to the way the emissions module currently works
   if (any(runs_distribution < min_runs_per_batch)) {
-    # Combineer kleine batches met hun buurman
+    # Combine small batches with their neighbor
     while (any(runs_distribution < min_runs_per_batch)) {
       idx <- which(runs_distribution < min_runs_per_batch)[1]
       if (idx > 1) {

--- a/R/fParallel.R
+++ b/R/fParallel.R
@@ -17,7 +17,7 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
     stop("Error: emissions_data cannot be NULL. Please provide a valid emissions dataset.")
   }
   
-  ###################### Step 1: load the scaled LHS samples
+  ###################### Step 1: Load the scaled samples
   LHSsamples <- readRDS(LHSsamples_path)
   
   ###################### Step 2: Prepare emissions and LHS samples for parallel solving
@@ -25,21 +25,37 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
   # Number of runs in the LHS matrix
   total_runs <- ncol(LHSsamples)
   
-  # Determine the number of batches and how runs are distributed across them
-  max_runs_per_batch <- max_runs_per_batch
-  nbatches <- total_runs %/% max_runs_per_batch
-  extra_runs <- total_runs %% max_runs_per_batch
+  # Minimum runs per batch
+  min_runs_per_batch <- 2
   
-  if (extra_runs != 0) {
-    nbatches <- nbatches + 1
+  # Maximum runs per batch (zoals opgegeven)
+  max_runs_per_batch <- max_runs_per_batch
+  
+  # Bepaal het minimale aantal batches zodat elke batch minstens 2 runs heeft
+  nbatches <- ceiling(total_runs / max_runs_per_batch)
+  
+  # Herverdeel de runs zodat elke batch minstens 2 runs heeft
+  runs_distribution <- rep(floor(total_runs / nbatches), nbatches)
+  remaining <- total_runs - sum(runs_distribution)
+  
+  # Verdeel de overgebleven runs over de eerste batches
+  if (remaining > 0) {
+    runs_distribution[1:remaining] <- runs_distribution[1:remaining] + 1
   }
   
-  # Add runs per batch to a vector
-  runs_distribution <- rep(max_runs_per_batch, nbatches)
-  
-  if (extra_runs != 0) {
-    # Override the last batch to fit the remaining runs
-    runs_distribution[length(runs_distribution)] <- extra_runs
+  # Controleer of alle batches minstens 2 runs hebben
+  if (any(runs_distribution < min_runs_per_batch)) {
+    # Combineer kleine batches met hun buurman
+    while (any(runs_distribution < min_runs_per_batch)) {
+      idx <- which(runs_distribution < min_runs_per_batch)[1]
+      if (idx > 1) {
+        runs_distribution[idx - 1] <- runs_distribution[idx - 1] + runs_distribution[idx]
+        runs_distribution <- runs_distribution[-idx]
+      } else {
+        runs_distribution[idx + 1] <- runs_distribution[idx + 1] + runs_distribution[idx]
+        runs_distribution <- runs_distribution[-idx]
+      }
+    }
   }
   
   # Split emissions data into chunks using the runs_distribution
@@ -56,7 +72,6 @@ solveInParallelSteadyState <- function(max_runs_per_batch,
   start_index <- 1
   for (run in runs_distribution) {
     end_index <- start_index + run - 1
-    # Ensure we don't exceed the total number of columns in the LHSsamples matrix
     slice <- LHSsamples[, start_index:min(end_index, total_runs), drop = FALSE]
     colnames(slice) <- colnames(LHSsamples)[start_index:min(end_index, total_runs)]
     LHS_slices[[length(LHS_slices) + 1]] <- slice
@@ -166,27 +181,44 @@ solveInParallelDynamic <- function(max_runs_per_batch,
   LHSsamples <- readRDS(LHSsamples_path)
   
   ###################### Step 2: Prepare emissions and LHS samples for parallel solving
-  
-  # Divide the emissions and LHS samples over different lists as evenly as possible for parallel solving
+
+    # Number of runs in the LHS matrix
   total_runs <- ncol(LHSsamples)
+  
+  # Minimum runs per batch
+  min_runs_per_batch <- 2
+  
+  # Maximum runs per batch (zoals opgegeven)
   max_runs_per_batch <- max_runs_per_batch
   
-  nbatches <- total_runs %/% max_runs_per_batch
-  extra_runs <- total_runs %% max_runs_per_batch
+  # Bepaal het minimale aantal batches zodat elke batch minstens 2 runs heeft
+  nbatches <- ceiling(total_runs / max_runs_per_batch)
   
-  if (extra_runs != 0) {
-    nbatches <- nbatches + 1
+  # Herverdeel de runs zodat elke batch minstens 2 runs heeft
+  runs_distribution <- rep(floor(total_runs / nbatches), nbatches)
+  remaining <- total_runs - sum(runs_distribution)
+  
+  # Verdeel de overgebleven runs over de eerste batches
+  if (remaining > 0) {
+    runs_distribution[1:remaining] <- runs_distribution[1:remaining] + 1
   }
   
-  # Initialize a vector to store the number of runs per core
-  runs_distribution <- rep(max_runs_per_batch, nbatches)
-  
-  if (extra_runs != 0) {
-    # Overwrite the last batch with the number in extra_runs
-    runs_distribution[length(runs_distribution)] <- extra_runs
+  # Controleer of alle batches minstens 2 runs hebben
+  if (any(runs_distribution < min_runs_per_batch)) {
+    # Combineer kleine batches met hun buurman
+    while (any(runs_distribution < min_runs_per_batch)) {
+      idx <- which(runs_distribution < min_runs_per_batch)[1]
+      if (idx > 1) {
+        runs_distribution[idx - 1] <- runs_distribution[idx - 1] + runs_distribution[idx]
+        runs_distribution <- runs_distribution[-idx]
+      } else {
+        runs_distribution[idx + 1] <- runs_distribution[idx + 1] + runs_distribution[idx]
+        runs_distribution <- runs_distribution[-idx]
+      }
+    }
   }
   
-  # Split emissions data into chunks based on computed runs_distribution
+  # Split emissions data into chunks using the runs_distribution
   emis_slices <- list()
   start_index <- 1
   for (runs in runs_distribution) {
@@ -195,12 +227,11 @@ solveInParallelDynamic <- function(max_runs_per_batch,
     start_index <- end_index + 1
   }
   
-  # Slice LHS samples based on runs_distribution
+  # Slice the LHS samples into chunks, matching the batch distribution
   LHS_slices <- list()
   start_index <- 1
   for (run in runs_distribution) {
     end_index <- start_index + run - 1
-    # Ensure we don't exceed the total number of columns in the LHS data
     slice <- LHSsamples[, start_index:min(end_index, total_runs), drop = FALSE]
     colnames(slice) <- colnames(LHSsamples)[start_index:min(end_index, total_runs)]
     LHS_slices[[length(LHS_slices) + 1]] <- slice


### PR DESCRIPTION
With this fix a minimum of 2 runs is always selected per batch. This is to prevent mistakes in the emission module, which works differently if only one run with emissions is given.