### PR TITLE
Fix chem class

### DIFF
--- a/R/v_KocAltDorC.R
+++ b/R/v_KocAltDorC.R
@@ -9,7 +9,7 @@
 #' @param pKa Dissociation constant of (conjugated) acid (default = 7)
 
 #' @export
-KocAltDorC <- function (Kow, a, b, pKa, KocAlt){
+KocAltDorC <- function (Kow, a, b, pKa, KocAlt, ChemClass){
 
     if (is.na(KocAlt) || KocAlt == "NA") { 
       if (is.na(pKa) || pKa == "NA"){

--- a/R/v_KocDorC.R
+++ b/R/v_KocDorC.R
@@ -8,7 +8,7 @@
 #' @param Koc Organic Carbon partitioning coefficient in
 #' @param pKa Dissociation constant of (conjugated) acid (default = 7)
 #' @export
-KocDorC <- function (Kow, a, b, Koc){
+KocDorC <- function (Kow, a, b, Koc, ChemClass){
 
     if (is.na(Koc) || Koc == "NA") { 
       switch(ChemClass,


### PR DESCRIPTION
ChemClass was missing in some functions. This was not noticed due to ChemClass object in global environment. This is problematic.
 rm(ChemClass) after init...